### PR TITLE
Update WeAPIVertExpand for latest WG and WE

### DIFF
--- a/src/WGExtender/wgcommandprocess/vertexpand/WeAPIVertExpand.java
+++ b/src/WGExtender/wgcommandprocess/vertexpand/WeAPIVertExpand.java
@@ -17,18 +17,20 @@
 
 package WGExtender.wgcommandprocess.vertexpand;
 
+import org.bukkit.entity.Player;
+
 import WGExtender.WGExtender;
 
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.Vector;
-import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.LocalPlayer;
 import com.sk89q.worldedit.regions.Region;
 
 public class WeAPIVertExpand implements VertExpandInterface {
 
 	@Override
-	public boolean expand(org.bukkit.entity.Player player) {
-		Player weplayer = WGExtender.getInstance().getWorldEdit().wrapPlayer(player);
+	public boolean expand(Player player) {
+		LocalPlayer weplayer = WGExtender.getInstance().getWorldEdit().wrapPlayer(player);
 		LocalSession session = WGExtender.getInstance().getWorldEdit().getSession(player);
         try {
 			Region region = session.getSelection(weplayer.getWorld());


### PR DESCRIPTION
When I've tried to rebuild the WGExtender (with WE-5.5.8, WG-6, latest Bukkit API, and Vault-1.5.0, compilation failed: 

```
...
src/WGExtender/wgcommandprocess/vertexpand/WeAPIVertExpand.java:24: error: package com.sk89q.worldedit.entity does not exist
    [javac] import com.sk89q.worldedit.entity.Player;
    [javac]                                  ^
    [javac] src/WGExtender/wgcommandprocess/vertexpand/WeAPIVertExpand.java:31: error: cannot find symbol
    [javac]         Player weplayer = WGExtender.getInstance().getWorldEdit().wrapPlayer(player);
    [javac]         ^
    [javac]   symbol:   class Player
    [javac]   location: class WeAPIVertExpand
...
```

As com.sk89q.worldedit.entity seems to be missing from latest WE versions, I've changed the class to use LocalPlayer instead of com.sk89q.worldedit.entity. The usage of the LocalPlayer seems to be possible, according to RegionSelector and LocalPlayer JavaDocs.

The modified WGEx compiles and auto-expand is working.
