### PR TITLE
Specify default group for damage-animals flag

### DIFF
--- a/src/WGExtender/flags/AnimalProtectFlag.java
+++ b/src/WGExtender/flags/AnimalProtectFlag.java
@@ -17,6 +17,7 @@
 
 package WGExtender.flags;
 
+import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 
 public class AnimalProtectFlag extends StateFlag {
@@ -39,7 +40,7 @@ public class AnimalProtectFlag extends StateFlag {
 	}
 
 	public AnimalProtectFlag() {
-		super("damage-animals", true);
+		super("damage-animals", true, RegionGroup.NON_MEMBERS);
 	}
 
 }


### PR DESCRIPTION
As of latest version of WG and WGEx the default group for damage-animals flag is all, which causes confusion (as it is incoherent with behavior of other state flags, used to prevent grief (such as enderpearl, lighter or potionsplash)). This commit changes the default RegionGroup for the damage-animals flag to RegionGroup.NON_MEMBERS (others), which is the behavior expected by many (including server administrators) and predicted by other grief-prevention state flag.

An alternative way to solve the issue of confusion with the behavior is to specify the default group under configuration node customflags.damage-animals.defaultgroup.
